### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: Build and Publish WPF .NET 8 App
+permissions:
+  contents: read
+  actions: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/QingTian1927/SmartBook/security/code-scanning/2](https://github.com/QingTian1927/SmartBook/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's code during the `actions/checkout` step.
- `actions: write` for uploading artifacts using `actions/upload-artifact`.

The `permissions` block will be added after the `name` field at the top of the file to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
